### PR TITLE
Updated OnToggleClickListener() access level

### DIFF
--- a/customtogglebutton/src/main/java/com/jackandphantom/customtogglebutton/CustomToggle.java
+++ b/customtogglebutton/src/main/java/com/jackandphantom/customtogglebutton/CustomToggle.java
@@ -270,7 +270,7 @@ public class CustomToggle extends View {
     }
 
     /* Interface for Checking which side of button  is enabled */
-    interface OnToggleClickListener {
+    public interface OnToggleClickListener {
         void onLefToggleEnabled(boolean enabled);
         void onRightToggleEnabled(boolean enabled);
     }


### PR DESCRIPTION
OnToggleClickListener() needs to be public in order to use it from Java class.